### PR TITLE
Adding a new option to MultinomClassify function to output full posterior probability matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Depends:
     data.table,
     dplyr,
     stringr,
-    rlang
+    rlang,
+    Matrix
 Imports:
   Rcpp (>= 0.11.1), RcppParallel, tibble
 LinkingTo: Rcpp (>= 0.11.1), RcppEigen, RcppParallel

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,8 +9,8 @@ charToInt <- function(Seq) {
     .Call('_microclass_charToInt', PACKAGE = 'microclass', Seq)
 }
 
-multinomClassifyCpp <- function(seqs, K, QMat, Prior, posterior) {
-    .Call('_microclass_multinomClassifyCpp', PACKAGE = 'microclass', seqs, K, QMat, Prior, posterior)
+multinomClassifyCpp <- function(seqs, K, QMat, Prior, posterior, fullmat) {
+    .Call('_microclass_multinomClassifyCpp', PACKAGE = 'microclass', seqs, K, QMat, Prior, posterior, fullmat)
 }
 
 multinomTrainCpp <- function(seqs, K, names, classesIn, nPseudo) {

--- a/R/multinom.R
+++ b/R/multinom.R
@@ -138,6 +138,8 @@ multinomClassify <- function(sequence, multinom.prob, post.prob = FALSE, prior =
     probs <- (exp(adjusted))/(rowSums(exp(adjusted)))
     probs[probs < 1e-10] = 0
     probs[probs > 1-1e-10] = 1
+    colnames(probs) = rownames(multinom.prob)
+    rownames(probs) = sequence
     probsmat <- Matrix::Matrix(probs,sparse=TRUE)
     return(probsmat)
   } else {

--- a/R/multinom.R
+++ b/R/multinom.R
@@ -72,6 +72,7 @@ multinomTrain <- function(sequence, taxon, K = 5, col.names = FALSE, n.pseudo = 
 #' @param post.prob Logical indicating if posterior log-probabilities should be returned.
 #' @param prior Logical indicating if classification should be done by flat priors (default)
 #' or with empirical priors.
+#' @param full.post.prob Logical indicating if full posterior probability matrix should be returned.
 #' 
 #' @details The classification step of the multinomial method (Vinje et al, 2015) means counting 
 #' K-mers on all sequences, and computing the posterior probabilities for each
@@ -118,17 +119,27 @@ multinomTrain <- function(sequence, taxon, K = 5, col.names = FALSE, n.pseudo = 
 #' 
 #' @export multinomClassify
 #' 
-multinomClassify <- function(sequence, multinom.prob, post.prob = FALSE, prior = FALSE){
+multinomClassify <- function(sequence, multinom.prob, post.prob = FALSE, prior = FALSE, full.post.prob = FALSE){
   int.list <- charToInt(sequence)
   if(prior){
     priors <- log2(attr(multinom.prob, "prior"))
   } else {
     priors <- rep(0, nrow(multinom.prob))
   }
-  X <- multinomClassifyCpp(int.list, log(ncol(multinom.prob), 4), multinom.prob, priors, post.prob)
+  X <- multinomClassifyCpp(int.list, log(ncol(multinom.prob), 4), multinom.prob, priors, post.prob, full.post.prob)
   if(post.prob){
     return(data.frame(taxon = rownames(multinom.prob)[X$first_ind], post_prob = X$first,
                       post_prob_2 = X$second, stringsAsFactors = FALSE))
+  } else if (full.post.prob){
+    logprobs <- X$ProbMat
+    const <- 700-apply(logprobs,1,max)
+    adjusted <- logprobs+const # add a constant (to be canceled out) to log-posterior to avoid numerical issues.
+    adjusted[adjusted < -700] = -700
+    probs <- (exp(adjusted))/(rowSums(exp(adjusted)))
+    probs[probs < 1e-10] = 0
+    probs[probs > 1-1e-10] = 1
+    probsmat <- Matrix::Matrix(probs,sparse=TRUE)
+    return(probsmat)
   } else {
     return(rownames(multinom.prob)[X$first_ind])
   }

--- a/man/multinomClassify.Rd
+++ b/man/multinomClassify.Rd
@@ -4,7 +4,13 @@
 \alias{multinomClassify}
 \title{Classifying with a Multinomial model}
 \usage{
-multinomClassify(sequence, multinom.prob, post.prob = FALSE, prior = FALSE)
+multinomClassify(
+  sequence,
+  multinom.prob,
+  post.prob = FALSE,
+  prior = FALSE,
+  full.post.prob = FALSE
+)
 }
 \arguments{
 \item{sequence}{Character vector of sequences to classify.}
@@ -15,6 +21,8 @@ multinomClassify(sequence, multinom.prob, post.prob = FALSE, prior = FALSE)
 
 \item{prior}{Logical indicating if classification should be done by flat priors (default)
 or with empirical priors.}
+
+\item{full.post.prob}{Logical indicating if full posterior probability matrix should be returned.}
 }
 \value{
 If \code{post.prob = FALSE} a character vector of predicted taxa is returned.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -36,8 +36,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // multinomClassifyCpp
-List multinomClassifyCpp(List seqs, int K, NumericMatrix QMat, NumericVector Prior, bool posterior);
-RcppExport SEXP _microclass_multinomClassifyCpp(SEXP seqsSEXP, SEXP KSEXP, SEXP QMatSEXP, SEXP PriorSEXP, SEXP posteriorSEXP) {
+List multinomClassifyCpp(List seqs, int K, NumericMatrix QMat, NumericVector Prior, bool posterior, bool fullmat);
+RcppExport SEXP _microclass_multinomClassifyCpp(SEXP seqsSEXP, SEXP KSEXP, SEXP QMatSEXP, SEXP PriorSEXP, SEXP posteriorSEXP, SEXP fullmatSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -46,7 +46,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericMatrix >::type QMat(QMatSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type Prior(PriorSEXP);
     Rcpp::traits::input_parameter< bool >::type posterior(posteriorSEXP);
-    rcpp_result_gen = Rcpp::wrap(multinomClassifyCpp(seqs, K, QMat, Prior, posterior));
+    Rcpp::traits::input_parameter< bool >::type fullmat(fullmatSEXP);
+    rcpp_result_gen = Rcpp::wrap(multinomClassifyCpp(seqs, K, QMat, Prior, posterior, fullmat));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -69,7 +70,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_microclass_Kmer_count", (DL_FUNC) &_microclass_Kmer_count, 3},
     {"_microclass_charToInt", (DL_FUNC) &_microclass_charToInt, 1},
-    {"_microclass_multinomClassifyCpp", (DL_FUNC) &_microclass_multinomClassifyCpp, 5},
+    {"_microclass_multinomClassifyCpp", (DL_FUNC) &_microclass_multinomClassifyCpp, 6},
     {"_microclass_multinomTrainCpp", (DL_FUNC) &_microclass_multinomTrainCpp, 5},
     {NULL, NULL, 0}
 };


### PR DESCRIPTION
Dear Developers of microclass,

Thank you for developing `microclass` which is super useful for taxonomic assignment. I am trying to incorporate your package into an ongoing research project which investigates the uncertainty of taxonomic assignment, such that for every given sequence I would love to have its posterior probabilities of belonging to any taxa.

I modified `MultinomClassify` and `multinomClassifyCpp` functions, such that there is a new option `full.post.prob` which allows output of full probability matrix. By default `full.post.prob = FALSE` and it shouldn't interfere other options such as `post.prob`. The output matrix will be transformed from log scale to [0,1] probability scale. It will be great if this can be merged to your current package, so that we can seamlessly incorporate `microclass` in our microbiome pipeline and get notified for updates in the future.

Thank you in advance for reviewing this pull request. I appreciate your time and effort.

Best,
Teng Fei